### PR TITLE
:pencil: Isolate when coverage runs

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -55,7 +55,7 @@ def tests(session, django):
 @nox.session
 def coverage(session):
     session.install(".[dev]")
-    session.run("python", "-m", "pytest")
+    session.run("python", "-m", "pytest", "--cov=email_relay")
     session.run("python", "-m", "coverage", "html", "--skip-covered", "--skip-empty")
     session.run("python", "-m", "coverage", "report", "--fail-under=50")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,7 +151,7 @@ ignore_missing_model_attributes = true
 [tool.pytest.ini_options]
 django_find_project = false
 pythonpath = ". src"
-addopts = "--create-db --cov=email_relay -n auto --dist loadfile"
+addopts = "--create-db -n auto --dist loadfile"
 norecursedirs = ".* bin build dist *.egg htmlcov logs node_modules templates venv"
 python_files = "tests.py test_*.py *_tests.py"
 testpaths = ["tests"]


### PR DESCRIPTION
I meant to push this yesterday. The goal is to avoid doubling up with coverage runs. We can combine coverage report + HTML options into one pytest call, but they were not working for me yesterday, and I never quite dove in after fighting config changes all afternoon. 