### PR TITLE
:tractor: Migrate Black and pyupgrade to Ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,6 @@ repos:
         alias: autoformat
         args: ["--fix"]
 
-  - repo: https://github.com/psf/black
-    rev: 23.9.1
-    hooks:
-      - id: black
-        language_version: python3.11
-        args: [--target-version, "py311"]
-
   - repo: https://github.com/adamchainz/blacken-docs
     rev: "1.16.0"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,6 @@ repos:
       - id: django-upgrade
         args: [--target-version, "4.2"]
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
-    hooks:
-      - id: pyupgrade
-        args: ["--py38-plus"]
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.2
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         args: ["--py38-plus"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.292
+    rev: v0.1.2
     hooks:
       - id: ruff
         alias: autoformat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,24 +80,6 @@ packages = ["src/email_relay"]
 [tool.hatch.version]
 path = "src/email_relay/__init__.py"
 
-[tool.black]
-exclude = '''
-/(
-    \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-  | venv
-)/
-'''
-include = '\.pyi?$'
-line-length = 88
-
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
@@ -179,12 +161,14 @@ exclude = [
   ".git",
   ".github",
   ".hg",
+  ".mypy_cache",
   ".ruff_cache",
   ".svn",
   ".tox",
   ".venv",
   "__pypackages__",
   "_build",
+  "buck-out",
   "build",
   "dist",
   "migrations",
@@ -192,17 +176,32 @@ exclude = [
   "static",
   "venv",
 ]
+extend-include = ["*.pyi?"]
 
 per-file-ignores = {}
 
 # Same as Black.
 line-length = 88
+indent-width = 4
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 # Assume Python 3.11.
 target-version = "py311"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+# magic-trailing-comma = "respect"
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
 
 [tool.ruff.isort]
 force-single-line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ select = [
   "E", # Pycodestyle
   "F", # Pyflakes
   "I", # isort
+  "UP", # pyupgrade
 ]
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
@@ -187,8 +188,8 @@ indent-width = 4
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
-# Assume Python 3.11.
-target-version = "py311"
+# Assume Python >3.8.
+target-version = "py38"
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.
@@ -207,3 +208,7 @@ line-ending = "auto"
 force-single-line = true
 known-first-party = ["email_relay"]
 required-imports = ["from __future__ import annotations"]
+
+[tool.ruff.pyupgrade]
+# Preserve types, even if a file imports `from __future__ import annotations`.
+keep-runtime-typing = true

--- a/src/email_relay/backend.py
+++ b/src/email_relay/backend.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from django.core.mail import EmailMessage
 from django.core.mail.backends.base import BaseEmailBackend

--- a/src/email_relay/relay.py
+++ b/src/email_relay/relay.py
@@ -71,16 +71,14 @@ def send_all():
                     message.fail(log=msg)
                     logger.warning(msg)
             except Exception as err:
-                if isinstance(
-                    err,
-                    (
-                        smtplib.SMTPAuthenticationError,
-                        smtplib.SMTPDataError,
-                        smtplib.SMTPRecipientsRefused,
-                        smtplib.SMTPSenderRefused,
-                        socket_error,
-                    ),
-                ):
+                handled_exceptions = (
+                    smtplib.SMTPAuthenticationError,
+                    smtplib.SMTPDataError,
+                    smtplib.SMTPRecipientsRefused,
+                    smtplib.SMTPSenderRefused,
+                    socket_error,
+                )
+                if isinstance(err, handled_exceptions):
                     logger.debug(f"deferring message {message.id} due to {err}")
                     message.defer(log=str(err))
                     if message.retry_count >= app_settings.EMAIL_MAX_RETRIES:


### PR DESCRIPTION
Inspired by: https://astral.sh/blog/the-ruff-formatter

There might be some version weirdness to work through for the full black support to take. I noticed this gave an error when enabled:

```toml
# Like Black, respect magic trailing commas.
magic-trailing-comma = "respect"
```

See: https://docs.astral.sh/ruff/configuration/#using-pyprojecttoml