### PR TITLE
:tractor: Adds ruff formatter (replace black)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.2
     hooks:
-      - id: ruff
-        alias: autoformat
-        args: ["--fix"]
+      - id: ruff-format
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: "1.16.0"


### PR DESCRIPTION
I double checked last night and this appears to be the right way to invoke the black compatibility. 