### PR TITLE
adjust relay loop to always call secondary methods

### DIFF
--- a/src/email_relay/management/commands/runrelay.py
+++ b/src/email_relay/management/commands/runrelay.py
@@ -23,19 +23,17 @@ class Command(BaseCommand):
     def handle(self, *args, **options) -> None:
         logger.info("starting relay")
         while True:
-            while (
-                not Message.objects.queued().exists()
-                and not Message.objects.deferred().exists()
-            ):
-                msg = "queue is empty"
-                if app_settings.EMPTY_QUEUE_SLEEP > 0:
-                    msg += f", sleeping for {app_settings.EMPTY_QUEUE_SLEEP} seconds before checking queue again"
-                    time.sleep(app_settings.EMPTY_QUEUE_SLEEP)
-                logger.debug(msg)
+            if Message.objects.queued().exists() or Message.objects.deferred().exists():
+                send_all()
 
-            send_all()
             self.delete_old_messages()
             self.ping_healthcheck()
+
+            msg = "loop complete"
+            if app_settings.EMPTY_QUEUE_SLEEP > 0:
+                msg += f", sleeping for {app_settings.EMPTY_QUEUE_SLEEP} seconds before next loop"
+            logger.debug(msg)
+            time.sleep(app_settings.EMPTY_QUEUE_SLEEP)
 
     def delete_old_messages(self) -> None:
         if app_settings.MESSAGES_RETENTION_SECONDS is not None:
@@ -60,6 +58,7 @@ class Command(BaseCommand):
                 )
                 return
 
+            logger.debug("pinging healthcheck")
             response = requests.request(
                 method=app_settings.RELAY_HEALTHCHECK_METHOD,
                 url=app_settings.RELAY_HEALTHCHECK_URL,


### PR DESCRIPTION
The `delete_old_messages` and `ping_healthcheck` methods were only being called if there was email in the queue to send. Adjusted the flow of the `handle` method to always call these, regardless of whether there were queued emails or not.