### PR TITLE
:bookmark: bump version 0.3.0 -> 0.4.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.3.0
+current_version: 0.4.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.4.0]
+
 ### Added
 
 -   A `_email_relay_version` field to `RelayEmailData` to track the version of the schema used to serialize the data. This should allow for future changes to the schema to be handled more gracefully.
@@ -104,9 +106,10 @@ Initial release!
 
 Big thank you to the original authors of [`django-mailer`](https://github.com/pinax/django-mailer) for the inspiration and for doing the hard work of figuring out a good way of queueing emails in a database in the first place.
 
-[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.2.1...HEAD
+[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.4.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.0
 [0.1.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.1
 [0.2.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.0
 [0.2.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.1
 [0.3.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.3.0
+[0.4.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ Source = "https://github.com/westerveltco/django-email-relay"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.3.0"
+current_version = "0.4.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/email_relay/__init__.py
+++ b/src/email_relay/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from email_relay import __version__
 
 
 def test_version():
-    assert __version__ == "0.3.0"
+    assert __version__ == "0.4.0"


### PR DESCRIPTION
- `9635f65`: adjust pre-commit config
- `e07e558`: lint codebase
- `caafa0c`: :arrow_up: Bump actions/setup-python from 4 to 5 (#129)
- `ae0efe8`: :arrow_up: [pre-commit.ci] pre-commit autoupdate (#124)
- `0c91ffd`: :handshake: refactor `noxfile` by splitting test matrix across two commands (#131)
- `f5be96d`: Update AUTHORS.md (#134)
- `0e5a34c`: [pre-commit.ci] pre-commit autoupdate (#133)
- `1613d2c`: add `_email_relay_version` to `EmailRelayMessage` (#136)
- `3e927b5`: apply `django-twc-package` template (#137)
- `141a0c7`: fix link in AUTHORS
- `b436225`: revert to previous CHANGELOG
- `474c123`: revert to previous README
- `c67a06c`: bump template to 2024.10 (#139)
- `4b6ffaa`: bump template to v2024.13 (#140)
- `67a56f3`: bump template to v2024.16 (#142)
- `bc54e0a`: update changelog