### PR TITLE
:bookmark: bump version 0.4.0 -> 0.4.1

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.4.0
+current_version: 0.4.1
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.4.1]
+
 ### Fixed
 
 -   Added back Docker publishing to `release.yml` GitHub Actions workflow.
@@ -110,10 +112,11 @@ Initial release!
 
 Big thank you to the original authors of [`django-mailer`](https://github.com/pinax/django-mailer) for the inspiration and for doing the hard work of figuring out a good way of queueing emails in a database in the first place.
 
-[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.4.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.4.1...HEAD
 [0.1.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.0
 [0.1.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.1
 [0.2.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.0
 [0.2.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.1
 [0.3.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.3.0
 [0.4.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.0
+[0.4.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ Source = "https://github.com/westerveltco/django-email-relay"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.4.0"
+current_version = "0.4.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/email_relay/__init__.py
+++ b/src/email_relay/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from email_relay import __version__
 
 
 def test_version():
-    assert __version__ == "0.4.0"
+    assert __version__ == "0.4.1"


### PR DESCRIPTION
- `4978e2e`: add missing Docker publishing from release workflow (#145)