### PR TITLE
:bookmark: bump version 0.4.2 -> 0.4.3

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.17
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.4.2
+current_version: 0.4.3
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.4.3]
+
 ### Fixed
 
 -   Added all documentation pages back to `toctree`.
@@ -124,7 +126,7 @@ Initial release!
 
 Big thank you to the original authors of [`django-mailer`](https://github.com/pinax/django-mailer) for the inspiration and for doing the hard work of figuring out a good way of queueing emails in a database in the first place.
 
-[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.4.2...HEAD
+[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.4.3...HEAD
 [0.1.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.0
 [0.1.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.1
 [0.2.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.0
@@ -133,3 +135,4 @@ Big thank you to the original authors of [`django-mailer`](https://github.com/pi
 [0.4.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.0
 [0.4.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.1
 [0.4.2]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.2
+[0.4.3]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ Source = "https://github.com/westerveltco/django-email-relay"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.4.2"
+current_version = "0.4.3"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/email_relay/__init__.py
+++ b/src/email_relay/__init__.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 __template_version__ = "2024.17"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from email_relay import __version__
 
 
 def test_version():
-    assert __version__ == "0.4.2"
+    assert __version__ == "0.4.3"


### PR DESCRIPTION
- `2cafca5`: fix docs toctree (#150)
- `ed3152a`: add back missing copyright from `django-mailer` (#151)
- `c29af90`: add missing extras to package (#152)