### PR TITLE
:bookmark: bump version 0.4.3 -> 0.5.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.18
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.4.3
+current_version: 0.5.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.5.0]
+
 ### Added
 
 - Added support for Django 5.1 and 5.2.
@@ -139,7 +141,7 @@ Initial release!
 
 Big thank you to the original authors of [`django-mailer`](https://github.com/pinax/django-mailer) for the inspiration and for doing the hard work of figuring out a good way of queueing emails in a database in the first place.
 
-[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.4.3...HEAD
+[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.5.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.0
 [0.1.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.1
 [0.2.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.0
@@ -149,3 +151,4 @@ Big thank you to the original authors of [`django-mailer`](https://github.com/pi
 [0.4.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.1
 [0.4.2]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.2
 [0.4.3]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.3
+[0.5.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ Source = "https://github.com/westerveltco/django-email-relay"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.4.3"
+current_version = "0.5.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/email_relay/__init__.py
+++ b/src/email_relay/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.4.3"
+__version__ = "0.5.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from email_relay import __version__
 
 
 def test_version():
-    assert __version__ == "0.4.3"
+    assert __version__ == "0.5.0"


### PR DESCRIPTION
- `1a20f59`: [pre-commit.ci] pre-commit autoupdate (#141)
- `c435483`: [pre-commit.ci] pre-commit autoupdate (#155)
- `fb15b41`: add mise config to ignore
- `a72f917`: bump template to v2024.18 (#158)
- `dfb5f98`: [pre-commit.ci] pre-commit autoupdate (#159)
- `ac6b066`: [pre-commit.ci] pre-commit autoupdate (#161)
- `e576c05`: [pre-commit.ci] pre-commit autoupdate (#162)
- `9ff6066`: [pre-commit.ci] pre-commit autoupdate (#163)
- `c8fee51`: :robot: :arrow_up: [pre-commit.ci] pre-commit autoupdate (#164)
- `ef531c8`: [pre-commit.ci] pre-commit autoupdate (#166)
- `1024507`: Bump docker/build-push-action from 5 to 6 in the gha group (#165)
- `dfee190`: [pre-commit.ci] pre-commit autoupdate (#167)
- `9c80ef4`: [pre-commit.ci] pre-commit autoupdate (#168)
- `e273088`: [pre-commit.ci] pre-commit autoupdate (#169)
- `97eacd5`: [pre-commit.ci] pre-commit autoupdate (#170)
- `74a3a80`: :robot: [pre-commit.ci] pre-commit autoupdate (#171)
- `e2d7d2f`: [pre-commit.ci] pre-commit autoupdate (#174)
- `bc22122`: [pre-commit.ci] pre-commit autoupdate (#175)
- `7575a3f`: [pre-commit.ci] pre-commit autoupdate (#176)
- `8e5c6cb`: [pre-commit.ci] pre-commit autoupdate (#177)
- `9e86f2a`: [pre-commit.ci] pre-commit autoupdate (#178)
- `d2301c4`: [pre-commit.ci] pre-commit autoupdate (#179)
- `ca441eb`: [pre-commit.ci] pre-commit autoupdate (#180)
- `14050c4`: [pre-commit.ci] pre-commit autoupdate (#181)
- `4ca161a`: [pre-commit.ci] pre-commit autoupdate (#182)
- `136c8b7`: :robot: [pre-commit.ci] pre-commit autoupdate (#183)
- `662143e`: [pre-commit.ci] pre-commit autoupdate (#184)
- `71d7247`: [pre-commit.ci] pre-commit autoupdate (#185)
- `6a54e44`: [pre-commit.ci] pre-commit autoupdate (#186)
- `5d73dc9`: [pre-commit.ci] pre-commit autoupdate (#187)
- `e6a7689`: :robot: [pre-commit.ci] pre-commit autoupdate (#188)
- `c59371a`: [pre-commit.ci] pre-commit autoupdate (#189)
- `c6b55ee`: bump min Python version for `main` Django (#191)
- `6d90cab`: Drop support for Python 3.8 (#192)
- `36b365d`: drop support for Django 3.2 (#193)
- `801d0be`: add support for Django 5.1 (#194)
- `9a9488c`: add support for Django 5.2 (#195)