### PR TITLE
:bookmark: bump version 0.5.0 -> 0.6.0

### DIFF
--- a/.copier/package.yml
+++ b/.copier/package.yml
@@ -3,7 +3,7 @@ _commit: v2024.18
 _src_path: gh:westerveltco/django-twc-package
 author_email: josh@joshthomas.dev
 author_name: Josh Thomas
-current_version: 0.5.0
+current_version: 0.6.0
 django_versions:
 - '3.2'
 - '4.2'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.6.0]
+
 ### Added
 
 - Added support for Python 3.13.
@@ -160,7 +162,7 @@ Initial release!
 
 Big thank you to the original authors of [`django-mailer`](https://github.com/pinax/django-mailer) for the inspiration and for doing the hard work of figuring out a good way of queueing emails in a database in the first place.
 
-[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.5.0...HEAD
+[unreleased]: https://github.com/westerveltco/django-email-relay/compare/v0.6.0...HEAD
 [0.1.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.0
 [0.1.1]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.1.1
 [0.2.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.2.0
@@ -171,3 +173,4 @@ Big thank you to the original authors of [`django-mailer`](https://github.com/pi
 [0.4.2]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.2
 [0.4.3]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.4.3
 [0.5.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.5.0
+[0.6.0]: https://github.com/westerveltco/django-email-relay/releases/tag/v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ Source = "https://github.com/westerveltco/django-email-relay"
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.5.0"
+current_version = "0.6.0"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/src/email_relay/__init__.py
+++ b/src/email_relay/__init__.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from email_relay import __version__
 
 
 def test_version():
-    assert __version__ == "0.5.0"
+    assert __version__ == "0.6.0"


### PR DESCRIPTION
- `761e0be`: [pre-commit.ci] pre-commit autoupdate (#197)
- `668296a`: :robot: [pre-commit.ci] pre-commit autoupdate (#200)
- `19a8e40`: [pre-commit.ci] pre-commit autoupdate (#201)
- `1c5e043`: :robot: [pre-commit.ci] pre-commit autoupdate (#202)
- `88ba9ae`: [pre-commit.ci] pre-commit autoupdate (#203)
- `a23e7ef`: [pre-commit.ci] pre-commit autoupdate (#204)
- `dd65198`: [pre-commit.ci] pre-commit autoupdate (#205)
- `a01849d`: [pre-commit.ci] pre-commit autoupdate (#206)
- `82e1b20`: [pre-commit.ci] pre-commit autoupdate (#207)
- `114f26e`: [pre-commit.ci] pre-commit autoupdate (#208)
- `2ce122e`: bump Django 5.2 to full version in test suite (#209)
- `5daf47e`: drop support for Django 5.0 (#211)
- `c0d15bb`: add support for Python 3.13 (#212)
- `b61f01d`: fix versions in docs
- `f48ee08`: swap to using uv for project management (#213)
- `c02edd1`: move Dockerfile to base of repo (#214)
- `88bc152`: Only handle transport errors, fail on all other errors (#210)
- `7c3f774`: remove `lint` dependency group in favor of `uv run --with` (#215)
- `0e511f1`: remove references to old service module
- `d59a899`: update pre-commit config for project
- `83bf1ce`: fix Justfile
- `e0287f4`: update changelog
- `08a2e2e`: update changelog
- `6f59378`: add project Justfile and bump script