### PR TITLE
enable more ruff rule groups

### DIFF
--- a/.bin/bump.py
+++ b/.bin/bump.py
@@ -64,7 +64,7 @@ class CommandRunner:
 
     def _run_command(self, command: str) -> tuple[bool, str]:
         try:
-            output = subprocess.check_output(
+            output = subprocess.check_output(  # noqa: S602 - trusted release helper
                 command, shell=True, text=True, stderr=subprocess.STDOUT
             ).strip()
             return True, output
@@ -256,13 +256,15 @@ def release(
 
     version = get_release_version()
 
+    release_exists = True
     try:
         run("gh", "release", "view", f"v{version}")
-        if not force:
-            print(f"Release v{version} already exists!")
-            raise typer.Exit(1)
     except Exception:
-        pass
+        release_exists = False
+
+    if release_exists and not force:
+        print(f"Release v{version} already exists!")
+        raise typer.Exit(1)
 
     if not force and not dry_run:
         typer.confirm(f"Create release v{version}?", abort=True)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.18
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
       - id: ruff-format
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,9 +193,12 @@ fixable = ["A", "B", "C", "D", "E", "F", "I"]
 ignore = ["E501", "E741"]  # temporary
 select = [
   "B",  # flake8-bugbear
+  "DJ",  # flake8-django
   "E",  # Pycodestyle
   "F",  # Pyflakes
   "I",  # isort
+  "PT",  # flake8-pytest-style
+  "S",  # flake8-bandit
   "UP"  # pyupgrade
 ]
 unfixable = []

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -8,7 +8,7 @@ from email_relay.conf import app_settings
 
 
 @pytest.mark.parametrize(
-    "setting,default_setting",
+    ("setting", "default_setting"),
     [
         ("DATABASE_ALIAS", "email_relay_db"),
         ("EMAIL_MAX_BATCH", None),
@@ -32,7 +32,7 @@ def test_default_settings(setting, default_setting):
 
 
 @pytest.mark.parametrize(
-    "setting,user_setting",
+    ("setting", "user_setting"),
     [
         ("DATABASE_ALIAS", "custom_db_name"),
         ("EMAIL_MAX_BATCH", 10),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,7 +53,7 @@ class TestMessageManager:
         assert message_for_sending == message
 
     @pytest.mark.parametrize(
-        "status, expected",
+        ("status", "expected"),
         [
             (Status.QUEUED, True),
             (Status.DEFERRED, True),

--- a/tests/test_runrelay.py
+++ b/tests/test_runrelay.py
@@ -40,7 +40,7 @@ def test_command_with_empty_queue(runrelay, mailoutbox):
 
 
 @pytest.mark.parametrize(
-    "status,quantity,expected_sent",
+    ("status", "quantity", "expected_sent"),
     [
         (Status.QUEUED, 10, 10),
         (Status.DEFERRED, 10, 10),


### PR DESCRIPTION
## Summary
- enable Ruff DJ, PT, and S rule groups
- update pre-commit to use the ruff-check hook
- fix the new pytest-style findings and keep a narrow noqa for the trusted release helper

## Validation
- uvx ruff check --statistics
- uvx ruff check
- uvx nox --session lint
- uvx nox --session "test"
- uvx nox --session mypy