### PR TITLE
chore: enable core Ruff rule groups

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -47,11 +47,8 @@ def should_skip(python: str, django: str) -> bool:
         # Django 5.2 requires Python 3.10+
         return True
 
-    if django == DJ51 and version(python) < version(PY310):
-        # Django 5.1 requires Python 3.10+
-        return True
-
-    return False
+    # Django 5.1 requires Python 3.10+
+    return django == DJ51 and version(python) < version(PY310)
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,8 +174,8 @@ extend-include = ["*.pyi?"]
 indent-width = 4
 # Same as Black.
 line-length = 88
-# Assume Python >3.8
-target-version = "py38"
+# Same as requires-python.
+target-version = "py39"
 
 [tool.ruff.format]
 # Like Black, indent with spaces, rather than tabs.
@@ -192,10 +192,23 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 fixable = ["A", "B", "C", "D", "E", "F", "I"]
 ignore = ["E501", "E741"]  # temporary
 select = [
+  "A",  # flake8-builtins
   "B",  # flake8-bugbear
-  "E",  # Pycodestyle
+  "C4",  # flake8-comprehensions
+  "DJ",  # flake8-django
+  "DTZ",  # flake8-datetimez
+  "E",  # pycodestyle
   "F",  # Pyflakes
+  "G",  # flake8-logging-format
   "I",  # isort
+  "LOG",  # flake8-logging
+  "PIE",  # flake8-pie
+  "PT",  # flake8-pytest-style
+  "RET",  # flake8-return
+  "RUF100",  # unused noqa
+  "S",  # flake8-bandit
+  "SIM",  # flake8-simplify
+  "T20",  # flake8-print
   "UP"  # pyupgrade
 ]
 unfixable = []
@@ -206,6 +219,10 @@ known-first-party = ["email_relay"]
 required-imports = ["from __future__ import annotations"]
 
 [tool.ruff.lint.per-file-ignores]
+# Release helper intentionally shells out to Git/GitHub CLI and prints progress.
+".bin/bump.py" = ["PIE810", "S110", "S602", "T201"]
+# Sphinx uses this conventional variable name.
+"docs/conf.py" = ["A001"]
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["PLR2004", "S101", "TID252"]
 

--- a/src/email_relay/management/commands/runrelay.py
+++ b/src/email_relay/management/commands/runrelay.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
                         seconds=app_settings.MESSAGES_RETENTION_SECONDS
                     )
                 )
-            logger.debug(f"deleted {deleted_messages} messages")
+            logger.debug("deleted %s messages", deleted_messages)
 
     def ping_healthcheck(self) -> None:
         if app_settings.RELAY_HEALTHCHECK_URL is not None:
@@ -77,12 +77,14 @@ class Command(BaseCommand):
                     timeout=app_settings.RELAY_HEALTHCHECK_TIMEOUT,
                 )
             except requests.exceptions.RequestException as e:
-                logger.warning(f"healthcheck failed, got exception: {e}")
+                logger.warning("healthcheck failed, got exception: %s", e)
                 return
 
             if response.status_code == app_settings.RELAY_HEALTHCHECK_STATUS_CODE:
                 logger.debug("healthcheck ping successful")
             else:
                 logger.warning(
-                    f"healthcheck failed, got {response.status_code}, expected {app_settings.RELAY_HEALTHCHECK_STATUS_CODE}"
+                    "healthcheck failed, got %s, expected %s",
+                    response.status_code,
+                    app_settings.RELAY_HEALTHCHECK_STATUS_CODE,
                 )

--- a/src/email_relay/models.py
+++ b/src/email_relay/models.py
@@ -36,7 +36,7 @@ class MessageManager(models.Manager["Message"]):
                 self.deferred().prioritized(),  # type: ignore[attr-defined]
             )
         )
-        logger.debug(f"found {len(message_batch)} messages to send")
+        logger.debug("found %s messages to send", len(message_batch))
         if app_settings.EMAIL_MAX_BATCH is not None:
             msg = f"max batch size is {app_settings.EMAIL_MAX_BATCH}"
             if len(message_batch) > app_settings.EMAIL_MAX_BATCH:
@@ -45,8 +45,8 @@ class MessageManager(models.Manager["Message"]):
             message_batch = message_batch[: app_settings.EMAIL_MAX_BATCH]
         return message_batch
 
-    def get_message_for_sending(self, id: int) -> Message:
-        return self.filter(id=id).select_for_update(skip_locked=True).get()
+    def get_message_for_sending(self, message_id: int) -> Message:
+        return self.filter(id=message_id).select_for_update(skip_locked=True).get()
 
     def messages_available_to_send(self) -> bool:
         return self.queued().exists() or self.deferred().exists()  # type: ignore[attr-defined]
@@ -124,7 +124,7 @@ class Message(models.Model):
         # Overriding the save method in order to make sure that
         # modified field is updated even if it is not given as
         # a parameter to the update field argument.
-        update_fields = kwargs.get("update_fields", None)
+        update_fields = kwargs.get("update_fields")
         if update_fields:
             kwargs["update_fields"] = set(update_fields).union({"updated_at"})
 

--- a/src/email_relay/relay.py
+++ b/src/email_relay/relay.py
@@ -45,7 +45,7 @@ def send_all():
                 if email is not None:
                     email.connection = connection
                     email.send()
-                    logger.debug(f"sent message {message.id}")
+                    logger.debug("sent message %s", message.id)
                     message.mark_sent()
                     counts["sent"] += 1
                 else:
@@ -65,7 +65,7 @@ def send_all():
                     and message.retry_count >= app_settings.EMAIL_MAX_RETRIES
                 ):
                     logger.warning(
-                        f"max retries reached, marking message {message.id} as failed"
+                        "max retries reached, marking message %s as failed", message.id
                     )
                     message.fail(log=str(err))
                     connection = None
@@ -73,15 +73,15 @@ def send_all():
                     continue
 
                 logger.debug(
-                    f"deferring message {message.id} due to {err}", exc_info=True
+                    "deferring message %s due to %s", message.id, err, exc_info=True
                 )
                 message.defer(log=str(err))
                 connection = None
                 counts["deferred"] += 1
             except Exception as err:
-                logger.error(
-                    f"unexpected error processing message {message.id}, marking as failed.",
-                    exc_info=True,
+                logger.exception(
+                    "unexpected error processing message %s, marking as failed.",
+                    message.id,
                 )
                 message.fail(log=str(err))
                 connection = None
@@ -92,16 +92,21 @@ def send_all():
             and counts["deferred"] >= app_settings.EMAIL_MAX_DEFERRED
         ):
             logger.debug(
-                f"max deferred emails reached ({app_settings.EMAIL_MAX_DEFERRED}), stopping"
+                "max deferred emails reached (%s), stopping",
+                app_settings.EMAIL_MAX_DEFERRED,
             )
             break
 
         if app_settings.EMAIL_THROTTLE > 0:
             logger.debug(
-                f"throttling enabled, sleeping for {app_settings.EMAIL_THROTTLE} seconds"
+                "throttling enabled, sleeping for %s seconds",
+                app_settings.EMAIL_THROTTLE,
             )
             time.sleep(app_settings.EMAIL_THROTTLE)
 
     logger.info(
-        f"sent {counts['sent']} emails, deferred {counts['deferred']} emails, failed {counts['failed']} emails"
+        "sent %s emails, deferred %s emails, failed %s emails",
+        counts["sent"],
+        counts["deferred"],
+        counts["failed"],
     )

--- a/src/email_relay/service.py
+++ b/src/email_relay/service.py
@@ -26,7 +26,7 @@ def get_user_settings_from_env() -> dict[str, Any]:
         >>> get_user_settings_from_env()
         {'DEBUG': False}
     """
-    all_env_vars = {k: v for k, v in os.environ.items()}
+    all_env_vars = dict(os.environ)
     env_vars_dict = env_vars_to_nested_dict(all_env_vars)
     valid_settings = filter_valid_django_settings(env_vars_dict)
     return coerce_dict_values(valid_settings)
@@ -176,7 +176,7 @@ def run_relay_service() -> int:
     settings.configure(**SETTINGS)
     django.setup()
     call_command("migrate")
-    print("Starting email relay service...")
+    print("Starting email relay service...")  # noqa: T201
     call_command("runrelay")
     # should never get here, `runrelay` is an infinite loop
     # but if it does, exit with 0

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -8,7 +8,7 @@ from email_relay.conf import app_settings
 
 
 @pytest.mark.parametrize(
-    "setting,default_setting",
+    ("setting", "default_setting"),
     [
         ("DATABASE_ALIAS", "email_relay_db"),
         ("EMAIL_MAX_BATCH", None),
@@ -32,7 +32,7 @@ def test_default_settings(setting, default_setting):
 
 
 @pytest.mark.parametrize(
-    "setting,user_setting",
+    ("setting", "user_setting"),
     [
         ("DATABASE_ALIAS", "custom_db_name"),
         ("EMAIL_MAX_BATCH", 10),

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -78,7 +78,7 @@ def test_to_dict():
     email_dict = RelayEmailData.from_email_message(email_message).to_dict()
 
     assert email_dict == IsPartialDict(
-        **{
+        {
             "subject": email_message.subject,
             "body": email_message.body,
             "from_email": email_message.from_email,
@@ -111,7 +111,7 @@ def test_to_dict_multi_alternatives():
     email_dict = RelayEmailData.from_email_message(email_multi_alternatives).to_dict()
 
     assert email_dict == IsPartialDict(
-        **{
+        {
             "subject": email_multi_alternatives.subject,
             "body": email_multi_alternatives.body,
             "from_email": email_multi_alternatives.from_email,
@@ -147,7 +147,7 @@ def test_to_dict_with_attachment():
     email_dict = RelayEmailData.from_email_message(email).to_dict()
 
     assert email_dict == IsPartialDict(
-        **{
+        {
             "subject": email.subject,
             "body": email.body,
             "from_email": email.from_email,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -53,7 +53,7 @@ class TestMessageManager:
         assert message_for_sending == message
 
     @pytest.mark.parametrize(
-        "status, expected",
+        ("status", "expected"),
         [
             (Status.QUEUED, True),
             (Status.DEFERRED, True),

--- a/tests/test_runrelay.py
+++ b/tests/test_runrelay.py
@@ -40,7 +40,7 @@ def test_command_with_empty_queue(runrelay, mailoutbox):
 
 
 @pytest.mark.parametrize(
-    "status,quantity,expected_sent",
+    ("status", "quantity", "expected_sent"),
     [
         (Status.QUEUED, 10, 10),
         (Status.DEFERRED, 10, 10),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -71,7 +71,7 @@ def test_get_user_settings_from_env():
         "DEBUG": True,
     }
 
-    for k in env_vars.keys():
+    for k in env_vars:
         del os.environ[k]
 
 


### PR DESCRIPTION
## Summary
- Enable the shared core Ruff rule groups for `django-email-relay`.
- Apply trivial fixes and targeted ignores so Ruff passes.

## Validation
- `just lint`

## Why these rules

The goal here is a boring, broadly useful Ruff baseline for Python/Django projects: catch correctness issues, framework-specific mistakes, test quality problems, security footguns, naive datetime usage, logging problems, and low-noise readability issues without enabling higher-churn families like `ANN`, `ARG`, full `PL`, full `RUF`, or `TRY`.

| Ruff code | What it is | Why it is a good default |
|---|---|---|
| `E` | `pycodestyle` errors | A small baseline for Python style errors that are not handled purely by formatting. These are familiar, low-surprise checks. |
| `F` | `Pyflakes` | High-signal correctness checks: undefined names, unused imports, duplicate definitions, invalid string formatting, and other issues that are often real bugs. |
| `I` | `isort` import sorting | Keeps import blocks deterministic and easy to review. This removes one common source of mechanical diff noise. |
| `B` | `flake8-bugbear` | Catches practical Python footguns: mutable defaults, problematic exception handling, loop-binding mistakes, useless expressions, and similar bug-prone patterns. |
| `UP` | `pyupgrade` | Keeps code aligned with the repository's target Python version and removes obsolete compatibility patterns. This helps the codebase stay consistent as Python versions move forward. |
| `DJ` | `flake8-django` | Adds Django-specific checks for models, forms, and framework conventions. These catch issues general Python linters cannot see, such as risky `ModelForm` exposure or model definition problems. |
| `PT` | `flake8-pytest-style` | Keeps tests idiomatic and consistent: parametrization shape, `pytest.raises` usage, fixture style, and pytest-vs-unittest assertion patterns. |
| `S` | Bandit security rules | Provides a baseline for common security-sensitive mistakes: suspicious `mark_safe`, hardcoded secrets, weak randomness, subprocess hazards, unsafe temp files, and raw SQL-ish patterns. It is not a full security review, but it is a useful default safety net. |
| `DTZ` | timezone-aware datetime rules | Especially useful in Django apps, where naive datetimes can become production bugs. These rules encourage explicit timezone-aware datetime usage. |
| `G` | `flake8-logging-format` | Enforces lazy logging formatting instead of f-strings, `.format()`, or `%` interpolation before the log call. This preserves normal logging behavior and avoids doing formatting work when the message is not emitted. |
| `LOG` | logging convention rules | Catches broader logging issues such as root logger usage, weak exception logging, redundant exception text, and logger setup problems. Good logging conventions improve diagnostics without changing application behavior. |
| `T20` | `print()` checks | In application and package code, stdout is usually the wrong interface for diagnostics. This nudges code toward logging, explicit CLI output, test assertions, or deletion. |
| `A` | builtin shadowing | Flags names like `id`, `type`, `list`, `filter`, and `input`. Avoiding builtin shadowing keeps code clearer and avoids subtle surprises when those builtins are needed later. |
| `C4` | comprehension cleanup | Catches redundant or inefficient comprehension patterns, such as unnecessary intermediate lists. These are usually straightforward readability/performance improvements. |
| `PIE` | `flake8-pie` small correctness/cleanup rules | A collection of low-noise checks for minor correctness and maintainability issues, such as unnecessary kwargs expansion, duplicate enum values, and repeated `startswith`/`endswith` patterns. |
| `RET` | return-path cleanup | Simplifies control flow by catching unnecessary `else` after `return`, redundant assignment-before-return, and implicit return patterns. The result is easier-to-scan functions. |
| `SIM` | `flake8-simplify` | Finds simpler equivalent forms for common conditionals and expressions, such as `x in dict.keys()`, collapsible `if` statements, or redundant boolean logic. Useful when the simplification is obvious and low risk. |
| `RUF100` | unused `noqa` comments | Keeps suppressions honest. Dead `noqa` comments make it harder to tell which suppressions are still intentional and can hide future issues. |
